### PR TITLE
adds `allElements()` method in Value API

### DIFF
--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -141,10 +141,14 @@ export class Struct extends Value(
 
   elements(): Value[] {
     let singleValueFields = Object.create(null);
-    for (const [fieldName, values] of this.allFields()) {
-      singleValueFields[fieldName] = values[values.length - 1];
+    for (const [fieldName, value] of this.fields()) {
+      singleValueFields[fieldName] = value;
     }
     return Object.values(singleValueFields);
+  }
+
+  allElements(): Value[][] {
+    return Object.values(this._fields);
   }
 
   [Symbol.iterator](): IterableIterator<[string, Value]> {

--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -147,8 +147,9 @@ export class Struct extends Value(
     return Object.values(singleValueFields);
   }
 
-  allElements(): Value[][] {
-    return Object.values(this._fields);
+  allElements(): Value[] {
+    // TODO: this can use flat()  method once we have esnext
+    return [].concat.apply([], Object.values(this._fields));
   }
 
   [Symbol.iterator](): IterableIterator<[string, Value]> {

--- a/src/dom/Value.ts
+++ b/src/dom/Value.ts
@@ -164,7 +164,7 @@ export interface Value {
   elements(): Value[];
 
   /**
-   * For the Struct, List, and SExpression types, returns an array containing the container's
+   * For the Struct types, returns an array containing the container's
    * nested values; otherwise throws an Error.
    * If there are duplicate fields in a Struct, then it only returns all the values for that field.
    *
@@ -177,13 +177,14 @@ export interface Value {
    *         foo: 1,
    *         foo: null,
    *         foo: true,
+   *         bar: 10,
    *     }
    *
-   * a call to `elements()` would return a field name "foo" with a `dom.Boolean` representing `true`
-   * while a call to `allElements()` would return  a field name "foo" with an `Array` of
-   * `dom.Value`s: `[1, null, true]`.
+   * a call to `elements()` would return a field name "foo" with a `dom.Boolean` representing `true` and a field name "bar"
+   * with a `dom.Integer` representing `10`. while a call to `allElements()` would return all field values as an `Array` of
+   * `dom.Value`s: `[1, null, true, 10]`.
    */
-  allElements(): Value[][];
+  allElements(): Value[];
 
   /**
    * Allows for easy type casting from Value to a particular implementation of Value.
@@ -402,7 +403,7 @@ export function Value<Clazz extends Constructor>(
       this._unsupportedOperation("elements");
     }
 
-    allElements(): Value[][] {
+    allElements(): Value[] {
       this._unsupportedOperation("allElements");
     }
 

--- a/src/dom/Value.ts
+++ b/src/dom/Value.ts
@@ -159,8 +159,31 @@ export interface Value {
   /**
    * For the Struct, List, and SExpression types, returns an array containing the container's
    * nested values; otherwise throws an Error.
+   * If there are duplicate fields in a Struct, then it only returns the last value for that field.
    */
   elements(): Value[];
+
+  /**
+   * For the Struct, List, and SExpression types, returns an array containing the container's
+   * nested values; otherwise throws an Error.
+   * If there are duplicate fields in a Struct, then it only returns all the values for that field.
+   *
+   * Like the `elements()` method, but returns an array containing the field name/value pairs with *all* of
+   * the associated values to a field name, instead of field name/value pairs with just the last associated value
+   * to a field name. For example, for the
+   * following struct:
+   *
+   *     {
+   *         foo: 1,
+   *         foo: null,
+   *         foo: true,
+   *     }
+   *
+   * a call to `elements()` would return a field name "foo" with a `dom.Boolean` representing `true`
+   * while a call to `allElements()` would return  a field name "foo" with an `Array` of
+   * `dom.Value`s: `[1, null, true]`.
+   */
+  allElements(): Value[][];
 
   /**
    * Allows for easy type casting from Value to a particular implementation of Value.
@@ -377,6 +400,10 @@ export function Value<Clazz extends Constructor>(
 
     elements(): Value[] {
       this._unsupportedOperation("elements");
+    }
+
+    allElements(): Value[][] {
+      this._unsupportedOperation("allElements");
     }
 
     get(...pathElements: PathElement[]): Value | null {

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -540,11 +540,11 @@ describe('DOM', () => {
       assert.equal("Jessie", s1.elements()[0]['first']);
 
       // allElements returns values for given Struct where for a fieldname it contains an array of all values
-      assert.isTrue(Array.isArray(s.allElements()[0]));
-      assert.deepEqual([load('55'), load('41')], s.allElements()[0]);
-      assert.isTrue(Array.isArray(s1.allElements()[0]));
-      assert.equal("John", s1.allElements()[0][0]['first']);
-      assert.equal("Jessie", s1.allElements()[0][1]['first']);
+      assert.isTrue(Array.isArray(s.allElements()));
+      assert.deepEqual([load('55'), load('41')], s.allElements());
+      assert.isTrue(Array.isArray(s1.allElements()));
+      assert.equal("John", s1.allElements()[0]['first']);
+      assert.equal("Jessie", s1.allElements()[1]['first']);
 
       // Iteration
       for (let [fieldName, value] of s) {

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -539,6 +539,13 @@ describe('DOM', () => {
       assert.isFalse(Array.isArray(s.elements()[0]));
       assert.equal("Jessie", s1.elements()[0]['first']);
 
+      // allElements returns values for given Struct where for a fieldname it contains an array of all values
+      assert.isTrue(Array.isArray(s.allElements()[0]));
+      assert.deepEqual([load('55'), load('41')], s.allElements()[0]);
+      assert.isTrue(Array.isArray(s1.allElements()[0]));
+      assert.equal("John", s1.allElements()[0][0]['first']);
+      assert.equal("Jessie", s1.allElements()[0][1]['first']);
+
       // Iteration
       for (let [fieldName, value] of s) {
          assert.isTrue(typeof fieldName === "string");


### PR DESCRIPTION
*Issue #693*

*Description of changes:*
This PR works on adding `allElements()` along with `elements()` for Value API.

*Test:*
Adds unit tests for `allElements()`.