### PR TITLE
Update all references to the GitHub organization: amzn -> amazon-ion

### DIFF
--- a/.github/workflows/ion-test-driver.yml
+++ b/.github/workflows/ion-test-driver.yml
@@ -9,14 +9,14 @@ jobs:
       - name: Checkout ion-js
         uses: actions/checkout@master
         with:
-          repository: amzn/ion-js
+          repository: amazon-ion/ion-js
           ref: master
           path: ion-js
 
       - name: Checkout ion-test-driver
         uses: actions/checkout@master
         with:
-          repository: amzn/ion-test-driver
+          repository: amazon-ion/ion-test-driver
           ref: master
           path: ion-test-driver
 
@@ -36,7 +36,7 @@ jobs:
       - name: Run ion-test-driver
         run: python3 ion-test-driver/amazon/iontest/ion_test_driver.py -o output
           -i ion-js,${{ github.event.pull_request.head.repo.html_url }},${{ github.event.pull_request.head.sha }}
-          --replace ion-js,https://github.com/amzn/ion-js.git,$main
+          --replace ion-js,https://github.com/amazon-ion/ion-js.git,$main
 
       - name: Upload result
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: npm publish
         # skip npm publishing if running in a fork
-        if: github.repository == 'amzn/ion-js'
+        if: github.repository == 'amazon-ion/ion-js'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ion-tests"]
 	path = ion-tests
-	url = https://github.com/amzn/ion-tests.git
+	url = https://github.com/amazon-ion/ion-tests.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ information to effectively respond to your bug report or contribution.
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
 
-When filing an issue, please check [existing open](https://github.com/amzn/ion-js/issues), or [recently closed](https://github.com/amzn/ion-js/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already 
+When filing an issue, please check [existing open](https://github.com/amazon-ion/ion-js/issues), or [recently closed](https://github.com/amazon-ion/ion-js/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already 
 reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
 
 * A reproducible test case or series of steps
@@ -41,7 +41,7 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/amzn/ion-js/labels/help%20wanted) issues is a great place to start. 
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/amazon-ion/ion-js/labels/help%20wanted) issues is a great place to start. 
 
 
 ## Code of Conduct
@@ -56,7 +56,7 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/amzn/ion-js/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/amazon-ion/ion-js/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Amazon Ion JavaScript
-An implementation of [Amazon Ion](https://amzn.github.io/ion-docs/) for JavaScript written in TypeScript.
+An implementation of [Amazon Ion](https://amazon-ion.github.io/ion-docs/) for JavaScript written in TypeScript.
 
 [![NPM Version](https://img.shields.io/npm/v/ion-js.svg)](https://www.npmjs.com/package/ion-js)
-[![License](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/amzn/ion-js/blob/master/LICENSE)
-[![Documentation](https://img.shields.io/badge/docs-api-green.svg)](https://amzn.github.io/ion-js/api/index.html)
+[![License](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/amazon-ion/ion-js/blob/master/LICENSE)
+[![Documentation](https://img.shields.io/badge/docs-api-green.svg)](https://amazon-ion.github.io/ion-js/api/index.html)
 
 This package is tested with Node JS major versions **10**, **12**, **14**, **16**, and **18**.  While this library
 should be usable within browsers that support **ES5+**, please note that it is not currently being tested
@@ -46,8 +46,8 @@ version) are not designed or tested to behave correctly.
 
 You can include the Ion-js bundle (ES5 compatible) using the URLs
 
-* [ion-bundle.min.js](https://amzn.github.io/ion-js/browser/scripts/ion-bundle.min.js)
-* [ion-bundle.js](https://amzn.github.io/ion-js/browser/scripts/ion-bundle.js)
+* [ion-bundle.min.js](https://amazon-ion.github.io/ion-js/browser/scripts/ion-bundle.min.js)
+* [ion-bundle.js](https://amazon-ion.github.io/ion-js/browser/scripts/ion-bundle.js)
 
 These will create and initialize `window.ion` which has the same exact API as our `npm` package. Here is an example
 
@@ -64,7 +64,7 @@ These will create and initialize `window.ion` which has the same exact API as ou
 
 ### API
 
-[TypeDoc](https://typedoc.org/) generated documentation can be found at [here](https://amzn.github.io/ion-js/api/).
+[TypeDoc](https://typedoc.org/) generated documentation can be found at [here](https://amazon-ion.github.io/ion-js/api/).
 Please note that anything not documented in the the API documentation is not supported for public use and is
 subject to change in any version.
 
@@ -77,7 +77,7 @@ The easiest way to clone the `ion-js` repository and initialize its `ion-tests`
 submodule is to run the following command.
 
 ```
-$ git clone --recursive https://github.com/amzn/ion-js.git ion-js
+$ git clone --recursive https://github.com/amazon-ion/ion-js.git ion-js
 ```
 
 Alternatively, the submodule may be initialized independently from the clone
@@ -157,7 +157,7 @@ at `dist/browser/js/ion-bundle.js`.
 | shared symbol tables      | no            | yes           | none                                          |
 
 Notes:
-* [test/iontests.ts](https://github.com/amzn/ion-js/blob/master/test/iontests.ts) defines multiple skipList variables
+* [test/iontests.ts](https://github.com/amazon-ion/ion-js/blob/master/test/iontests.ts) defines multiple skipList variables
   referencing test vectors that are not expected to work at this time.
 
 * ion-js supports shared symbol table for Ion Binary. Below is an example of how shared symbol table can be used here: 
@@ -203,9 +203,9 @@ This library is licensed under [Apache License version 2.0](LICENSE)
 ## Links
 For more information about Ion or its other implementation, please see:
 
-* [Ion](https://amzn.github.io/ion-docs/)
-* [Ion Specification](https://amzn.github.io/ion-docs/spec.html)
-* [Ion Cookbook](https://amzn.github.io/ion-docs/cookbook.html) uses the Java library for its examples.
-* [Ion C](https://github.com/amzn/ion-c)
-* [Ion Java](https://github.com/amzn/ion-java)
-* [Ion Python](https://github.com/amzn/ion-python)
+* [Ion](https://amazon-ion.github.io/ion-docs/)
+* [Ion Specification](https://amazon-ion.github.io/ion-docs/spec.html)
+* [Ion Cookbook](https://amazon-ion.github.io/ion-docs/cookbook.html) uses the Java library for its examples.
+* [Ion C](https://github.com/amazon-ion/ion-c)
+* [Ion Java](https://github.com/amazon-ion/ion-java)
+* [Ion Python](https://github.com/amazon-ion/ion-python)

--- a/browser/index.html
+++ b/browser/index.html
@@ -8,7 +8,7 @@
   <h1> Ion JS in your browser</h1>
   <p>
   <button type="button" onclick="var ion = window.ion">Click me first</button> and then open the JS console 
-on your browser. The global variable <code>ion</code> may be used using the <a href="https://amzn.github.io/ion-js/api/modules/_ion_.html">API</a>. 
+on your browser. The global variable <code>ion</code> may be used using the <a href="https://amazon-ion.github.io/ion-js/api/modules/_ion_.html">API</a>.
   </p>
 
   <p>

--- a/package.json
+++ b/package.json
@@ -17,19 +17,19 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/amzn/ion-js.git"
+    "url": "https://github.com/amazon-ion/ion-js.git"
   },
   "keywords": [
     "ion",
     "JSON",
     "data format"
   ],
-  "author": "The Ion Team <ion-team@amazon.com> (https://amzn.github.io/ion-docs/index.html)",
+  "author": "The Ion Team <ion-team@amazon.com> (https://amazon-ion.github.io/ion-docs/index.html)",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/amzn/ion-js/issues"
+    "url": "https://github.com/amazon-ion/ion-js/issues"
   },
-  "homepage": "https://github.com/amzn/ion-js#readme",
+  "homepage": "https://github.com/amazon-ion/ion-js#readme",
   "config": {
     "commitizen": {
       "path": "node_modules/cz-conventional-changelog"

--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -52,7 +52,7 @@ enum States {
   CLOSED,
 }
 
-/** Four-bit type codes per http://amzn.github.io/ion-docs/binary.html#typed-value-formats */
+/** Four-bit type codes per https://amazon-ion.github.io/ion-docs/binary.html#typed-value-formats */
 enum TypeCodes {
   NULL = 0,
   BOOL = 1,
@@ -77,7 +77,7 @@ enum TypeCodes {
  * This implementation caches serialized values in an in-memory tree.
  * It does not support multiple local symbol tables (aka "symbol table append").
  *
- * @see http://amzn.github.io/ion-docs/binary.html
+ * @see https://amazon-ion.github.io/ion-docs/binary.html
  */
 export class BinaryWriter extends AbstractWriter {
   private readonly symbolTable: LocalSymbolTable;
@@ -167,7 +167,7 @@ export class BinaryWriter extends AbstractWriter {
     const isPositiveZero: boolean =
       JSBI.equal(coefficient, JsbiSupport.ZERO) && !value.isNegative();
     if (isPositiveZero && exponent === 0 && _sign(exponent) === 1) {
-      // Special case per the spec: http://amzn.github.io/ion-docs/docs/binary.html#5-decimal
+      // Special case per the spec: https://amazon-ion.github.io/ion-docs/docs/binary.html#5-decimal
       this.addNode(
         new BytesNode(
           this.writer,

--- a/src/IonCatalog.ts
+++ b/src/IonCatalog.ts
@@ -26,7 +26,7 @@ function byVersion(x: SharedSymbolTable, y: SharedSymbolTable): number {
 
 /**
  * A catalog holds available shared symbol tables and always includes the system symbol table.
- * @see https://amzn.github.io/ion-docs/docs/symbols.html#the-catalog
+ * @see https://amazon-ion.github.io/ion-docs/docs/symbols.html#the-catalog
  */
 export class Catalog {
   private symbolTables: SymbolTableIndex;

--- a/src/IonDecimal.ts
+++ b/src/IonDecimal.ts
@@ -43,7 +43,7 @@ export class Decimal {
   public static readonly ONE = new Decimal(1, 0);
 
   // For more information about the (sign, coefficient, exponent) data model, see:
-  // https://amzn.github.io/ion-docs/docs/decimal.html#data-model
+  // https://amazon-ion.github.io/ion-docs/docs/decimal.html#data-model
   // Note that while the scheme described in the above link uses an unsigned integer to represent its coefficient,
   // this class uses a signed integer. The sign of the value returned by `getCoefficient()` will always agree
   // with the sign returned by `isNegative()` except in the case of -0, which cannot be natively represented
@@ -373,7 +373,7 @@ export class Decimal {
     this._isNegative = isNegative;
     this._coefficient = coefficient;
     // If the exponent is -0, set it to 0, which is equivalent.
-    // See: https://github.com/amzn/ion-js/issues/474
+    // See: https://github.com/amazon-ion/ion-js/issues/474
     if (Object.is(-0, exponent)) {
       exponent = 0;
     }

--- a/src/IonImport.ts
+++ b/src/IonImport.ts
@@ -24,7 +24,7 @@ import { SharedSymbolTable } from "./IonSharedSymbolTable";
  * import from a given symbol table may be specified as the "length" of the
  * import.
  *
- * @see http://amzn.github.io/ion-docs/symbols.html#imports
+ * @see https://amazon-ion.github.io/ion-docs/symbols.html#imports
  */
 export class Import {
   private readonly _offset: number;

--- a/src/IonLowLevelBinaryWriter.ts
+++ b/src/IonLowLevelBinaryWriter.ts
@@ -20,7 +20,7 @@ import { JsbiSerde } from "./JsbiSerde";
 /**
  * Values in the Ion binary format are serialized as a sequence of low-level fields. This
  * writer is responsible for emitting those fields in the proper format.
- * @see http://amzn.github.io/ion-docs/binary.html#basic-field-formats
+ * @see https://amazon-ion.github.io/ion-docs/binary.html#basic-field-formats
  */
 export class LowLevelBinaryWriter {
   private readonly writeable: Writeable;

--- a/src/IonReader.ts
+++ b/src/IonReader.ts
@@ -92,7 +92,7 @@ export interface Reader {
   /** Returns the depth of the reader.  This is `0` if the reader is not inside of a container. */
   depth(): number;
 
-  // TODO implement symboltokens to replace string[] https://github.com/amzn/ion-js/issues/121
+  // TODO implement symboltokens to replace string[] https://github.com/amazon-ion/ion-js/issues/121
   /**
    * Returns the annotations for the current value.
    *

--- a/src/IonSharedSymbolTable.ts
+++ b/src/IonSharedSymbolTable.ts
@@ -15,7 +15,7 @@
 
 /**
  * A shared symbol table.
- * @see https://amzn.github.io/ion-docs/docs/symbols.html#shared-symbol-tables
+ * @see https://amazon-ion.github.io/ion-docs/docs/symbols.html#shared-symbol-tables
  */
 export class SharedSymbolTable {
   protected readonly _idsByText: Map<string, number>;

--- a/src/IonSubstituteSymbolTable.ts
+++ b/src/IonSubstituteSymbolTable.ts
@@ -18,7 +18,7 @@ import { SharedSymbolTable } from "./IonSharedSymbolTable";
 /**
  * A special case of shared symbol table whose entries are all undefined. Used in certain cases
  * when an import cannot be satisfied by the current catalog.
- * @see http://amzn.github.io/ion-docs/symbols.html#imports
+ * @see https://amazon-ion.github.io/ion-docs/symbols.html#imports
  */
 export class SubstituteSymbolTable extends SharedSymbolTable {
   constructor(length: number) {

--- a/src/IonSystemSymbolTable.ts
+++ b/src/IonSystemSymbolTable.ts
@@ -15,7 +15,7 @@
 
 /**
  * @file Helper methods for obtaining the system symbol table or its Import.
- * @see https://amzn.github.io/ion-docs/docs/symbols.html#system-symbols
+ * @see https://amazon-ion.github.io/ion-docs/docs/symbols.html#system-symbols
  */
 import { Import } from "./IonImport";
 import { SharedSymbolTable } from "./IonSharedSymbolTable";

--- a/src/IonTimestamp.ts
+++ b/src/IonTimestamp.ts
@@ -232,7 +232,7 @@ export class Timestamp {
    * The provided string must be a text-encoded Timestamp as specified
    * in the Ion specification.
    *
-   * @see https://amzn.github.io/ion-docs/docs/spec.html#timestamp
+   * @see https://amazon-ion.github.io/ion-docs/docs/spec.html#timestamp
    */
   static parse(str: string): Timestamp | null {
     return _TimestampParser._parse(str);

--- a/src/IonUnicode.ts
+++ b/src/IonUnicode.ts
@@ -27,7 +27,7 @@ if (typeof TextDecoder !== "undefined") {
 
 /**
  * @file Constants and helper methods for Unicode.
- * @see https://amzn.github.io/ion-docs/stringclob.html
+ * @see https://amazon-ion.github.io/ion-docs/stringclob.html
  * @see http://www.unicode.org/versions/Unicode5.0.0/
  */
 export function encodeUtf8(s: string): Uint8Array {

--- a/src/SignAndMagnitudeInt.ts
+++ b/src/SignAndMagnitudeInt.ts
@@ -22,7 +22,7 @@ import { JsbiSupport } from "./JsbiSupport";
  * BigInts cannot represent negative zero. This class should be used in situations where negative zero is
  * a supported value, such as when decoding binary Ion Int/VarInt.
  *
- * http://amzn.github.io/ion-docs/docs/binary.html#uint-and-int-fields
+ * https://amazon-ion.github.io/ion-docs/docs/binary.html#uint-and-int-fields
  *
  */
 export default class SignAndMagnitudeInt {

--- a/src/dom/Blob.ts
+++ b/src/dom/Blob.ts
@@ -4,7 +4,7 @@ import { Lob } from "./Lob";
 /**
  * Represents a blob[1] value in an Ion stream.
  *
- * [1] http://amzn.github.io/ion-docs/docs/spec.html#blob
+ * [1] https://amazon-ion.github.io/ion-docs/docs/spec.html#blob
  */
 export class Blob extends Lob(IonTypes.BLOB) {
   /**

--- a/src/dom/Boolean.ts
+++ b/src/dom/Boolean.ts
@@ -33,7 +33,7 @@ const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
  *          // this code WILL be executed
  *      }
  *
- * [1] http://amzn.github.io/ion-docs/docs/spec.html#bool
+ * [1] https://amazon-ion.github.io/ion-docs/docs/spec.html#bool
  * [2] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#Description
  */
 export class Boolean extends Value(

--- a/src/dom/Clob.ts
+++ b/src/dom/Clob.ts
@@ -4,7 +4,7 @@ import { Lob } from "./Lob";
 /**
  * Represents a clob[1] value in an Ion stream.
  *
- * [1] http://amzn.github.io/ion-docs/docs/spec.html#clob
+ * [1] https://amazon-ion.github.io/ion-docs/docs/spec.html#clob
  */
 export class Clob extends Lob(IonTypes.CLOB) {
   /**
@@ -26,7 +26,7 @@ export class Clob extends Lob(IonTypes.CLOB) {
     // we write each byte out as a Unicode escape (e.g. 127 -> 0x7f -> \u007f)
     // unless it happens to fall within the ASCII range.
     // See the Ion cookbook's guide to down-converting to JSON for details:
-    // http://amzn.github.io/ion-docs/guides/cookbook.html#down-converting-to-json
+    // https://amazon-ion.github.io/ion-docs/guides/cookbook.html#down-converting-to-json
     let encodedText = "";
     for (const byte of this) {
       if (byte >= 32 && byte <= 126) {

--- a/src/dom/Decimal.ts
+++ b/src/dom/Decimal.ts
@@ -15,7 +15,7 @@ const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
 /**
  * Represents a decimal[1] value in an Ion stream.
  *
- * [1] http://amzn.github.io/ion-docs/docs/spec.html#decimal
+ * [1] https://amazon-ion.github.io/ion-docs/docs/spec.html#decimal
  */
 export class Decimal extends Value(
   Number,

--- a/src/dom/Float.ts
+++ b/src/dom/Float.ts
@@ -16,7 +16,7 @@ const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
 /**
  * Represents a float[1] value in an Ion stream.
  *
- * [1] http://amzn.github.io/ion-docs/docs/spec.html#float
+ * [1] https://amazon-ion.github.io/ion-docs/docs/spec.html#float
  */
 export class Float extends Value(Number, IonTypes.FLOAT, _fromJsConstructor) {
   /**

--- a/src/dom/Integer.ts
+++ b/src/dom/Integer.ts
@@ -22,7 +22,7 @@ const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
 /**
  * Represents an integer value in an Ion stream.
  *
- * [1] http://amzn.github.io/ion-docs/docs/spec.html#int
+ * [1] https://amazon-ion.github.io/ion-docs/docs/spec.html#int
  */
 export class Integer extends Value(Number, IonTypes.INT, _fromJsConstructor) {
   private _bigIntValue: JSBI | null;

--- a/src/dom/List.ts
+++ b/src/dom/List.ts
@@ -5,7 +5,7 @@ import { Value } from "./Value";
 /**
  * Represents a list value in an Ion stream.
  *
- * [1] http://amzn.github.io/ion-docs/docs/spec.html#list
+ * [1] https://amazon-ion.github.io/ion-docs/docs/spec.html#list
  */
 export class List extends Sequence(IonTypes.LIST) {
   /**

--- a/src/dom/Null.ts
+++ b/src/dom/Null.ts
@@ -25,7 +25,7 @@ import { PathElement, Value } from "./Value";
  *      dollars::null.decimal
  *      meters::null.float
  *
- * [1] http://amzn.github.io/ion-docs/docs/spec.html#null
+ * [1] https://amazon-ion.github.io/ion-docs/docs/spec.html#null
  */
 export class Null extends Value(Object, IonTypes.NULL, FromJsConstructor.NONE) {
   private static _supportedIonTypesByOperation = new Map<string, Set<IonType>>([

--- a/src/dom/README.md
+++ b/src/dom/README.md
@@ -276,7 +276,7 @@ assert.isFalse(ionString === ionString2);
 
 This method compares a `dom.Value` object with another `dom.Value` object with either strict or non-strict comparison type. 
 
-*Strict equivalence* refers to Ion data model equivalence as defined in [Ion Equivalence](https://www.javadoc.io/doc/com.amazon.ion/ion-java/latest/com/amazon/ion/util/Equivalence.html) and by [Ion Specification](http://amzn.github.io/ion-docs/docs/spec.html)
+*Strict equivalence* refers to Ion data model equivalence as defined in [Ion Equivalence](https://www.javadoc.io/doc/com.amazon.ion/ion-java/latest/com/amazon/ion/util/Equivalence.html) and by [Ion Specification](https://amazon-ion.github.io/ion-docs/docs/spec.html)
 *Structural* (or *non-strict*) *equivalence* follows the same rules as strict equivalence,except that:
 * Annotations are not considered, and
 * Timestamps that represent the same instant in time are always considered equivalent.

--- a/src/dom/SExpression.ts
+++ b/src/dom/SExpression.ts
@@ -5,7 +5,7 @@ import { Value } from "./Value";
 /**
  * Represents an s-expression[1] value in an Ion stream.
  *
- * [1] http://amzn.github.io/ion-docs/docs/spec.html#sexp
+ * [1] https://amazon-ion.github.io/ion-docs/docs/spec.html#sexp
  */
 export class SExpression extends Sequence(IonTypes.SEXP) {
   /**

--- a/src/dom/String.ts
+++ b/src/dom/String.ts
@@ -15,7 +15,7 @@ const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
 /**
  * Represents a string[1] value in an Ion stream.
  *
- * [1] http://amzn.github.io/ion-docs/docs/spec.html#string
+ * [1] https://amazon-ion.github.io/ion-docs/docs/spec.html#string
  */
 export class String extends Value(
   _NativeJsString,

--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -22,7 +22,7 @@ import { PathElement, Value } from "./Value";
  *     let s: any = ion.load('{fieldNames: ["foo", "bar", "baz"]}'); // Conflicts with Struct#fieldNames()
  *     assert.equal(s.get('fieldNames', 0).stringValue(), "foo"); // Passes
  *
- * [1] http://amzn.github.io/ion-docs/docs/spec.html#struct
+ * [1] https://amazon-ion.github.io/ion-docs/docs/spec.html#struct
  */
 export class Struct extends Value(
   Object,

--- a/src/dom/Symbol.ts
+++ b/src/dom/Symbol.ts
@@ -18,7 +18,7 @@ const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
 /**
  * Represents a symbol[1] value in an Ion stream.
  *
- * [1] http://amzn.github.io/ion-docs/docs/spec.html#symbol
+ * [1] https://amazon-ion.github.io/ion-docs/docs/spec.html#symbol
  */
 export class Symbol extends Value(String, IonTypes.SYMBOL, _fromJsConstructor) {
   /**

--- a/src/dom/Timestamp.ts
+++ b/src/dom/Timestamp.ts
@@ -14,7 +14,7 @@ const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
 /**
  * Represents a timestamp[1] value in an Ion stream.
  *
- * [1] http://amzn.github.io/ion-docs/docs/spec.html#timestamp
+ * [1] https://amazon-ion.github.io/ion-docs/docs/spec.html#timestamp
  */
 export class Timestamp extends Value(
   Date,

--- a/src/dom/Value.ts
+++ b/src/dom/Value.ts
@@ -198,7 +198,7 @@ export interface Value {
    *      considered equivalent.
    *
    * [1] https://www.javadoc.io/doc/com.amazon.ion/ion-java/latest/com/amazon/ion/util/Equivalence.html
-   * [2] http://amzn.github.io/ion-docs/docs/spec.html
+   * [2] https://amazon-ion.github.io/ion-docs/docs/spec.html
    *
    * @param other                       other Ion Value to be compared with this Ion Value.
    * @param options                     options provided for equivalence as below

--- a/src/events/IonEventStream.ts
+++ b/src/events/IonEventStream.ts
@@ -607,7 +607,7 @@ export class IonEventStream {
 
   /** Parse the field name (Symbol Token) into text/symbol
    *  example: {event_type: SCALAR, ion_type: INT, field_name: {text:"foo"}, value_text: "1", value_binary: [0x21, 0x01], depth:1}
-   *  for more information: https://github.com/amzn/ion-test-driver#symboltoken-1
+   *  for more information: https://github.com/amazon-ion/ion-test-driver#symboltoken-1
    */
   private resolveFieldNameFromSerializedSymbolToken(): string | null {
     if (this.reader.isNull()) {

--- a/test-driver/package.json
+++ b/test-driver/package.json
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/amzn/ion-js.git"
+    "url": "https://github.com/amazon-ion/ion-js.git"
   },
-  "author": "The Ion Team <ion-team@amazon.com> (https://amzn.github.io/ion-docs/index.html)",
+  "author": "The Ion Team <ion-team@amazon.com> (https://amazon-ion.github.io/ion-docs/index.html)",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/amzn/ion-js/issues"
+    "url": "https://github.com/amazon-ion/ion-js/issues"
   },
-  "homepage": "https://github.com/amzn/ion-js#readme",
+  "homepage": "https://github.com/amazon-ion/ion-js#readme",
   "dependencies": {
     "yargs": "^15.4.1",
     "ion-js": "../"

--- a/test-driver/src/CliCommonArgs.ts
+++ b/test-driver/src/CliCommonArgs.ts
@@ -18,14 +18,14 @@ import fs from "fs";
 import yargs from "yargs";
 
 /** common CLI arguments structure
- *  for more information: https://github.com/amzn/ion-test-driver#standardized-cli
+ *  for more information: https://github.com/amazon-ion/ion-test-driver#standardized-cli
  */
 export class IonCliCommonArgs {
     inputFiles: Array<string>;
     outputFormatName: OutputFormat;
 
     // outputFile,errorReportFile: 'any' datatype to use stdout as well as file write stream to write ion data
-    // for more information : https://github.com/amzn/ion-js/issues/627
+    // for more information : https://github.com/amazon-ion/ion-js/issues/627
     outputFile: any;
     errorReportFile: any;
 

--- a/test-driver/src/CliError.ts
+++ b/test-driver/src/CliError.ts
@@ -23,7 +23,7 @@ export enum ErrorType {
 }
 
 /** Error structure for error report
- * for more information: https://github.com/amzn/ion-test-driver#errorreport
+ * for more information: https://github.com/amazon-ion/ion-test-driver#errorreport
  */
 export class IonCliError {
     errorType: ErrorType;

--- a/test-driver/src/ComparisonContext.ts
+++ b/test-driver/src/ComparisonContext.ts
@@ -23,7 +23,7 @@ import {IonEvent, IonEventFactory, IonEventType} from "ion-js";
 
 /**
  * ComparisonContext to create a structure for lhs and rhs streams
- * for more information: https://github.com/amzn/ion-test-driver#comparisonreport
+ * for more information: https://github.com/amazon-ion/ion-test-driver#comparisonreport
  */
 export class ComparisonContext {
     location: string;

--- a/test-driver/src/ComparisonReport.ts
+++ b/test-driver/src/ComparisonReport.ts
@@ -19,7 +19,7 @@ import {ComparisonContext} from "./ComparisonContext";
 import {ComparisonResultType} from "ion-js";
 
 /** comparison report structure for compare
- *  for more information: https://github.com/amzn/ion-test-driver#comparisonreport
+ *  for more information: https://github.com/amazon-ion/ion-test-driver#comparisonreport
  */
 export class IonComparisonReport {
     lhs: ComparisonContext;

--- a/test/IonLocalSymbolTable.ts
+++ b/test/IonLocalSymbolTable.ts
@@ -141,7 +141,7 @@ describe('Local symbol table', () => {
         assert.equal(originalLength + 1, symbolTable.symbols.length, "Duplicate symbol added to symbol table");
     });
 
-    // See https://github.com/amzn/ion-js/issues/645
+    // See https://github.com/amazon-ion/ion-js/issues/645
     it('SST Object properties are not treated as symbols (Issue #645)', () => {
         const symbolTable = defaultLocalSymbolTable();
         symbolTable.addSymbol("foo");
@@ -156,7 +156,7 @@ describe('Local symbol table', () => {
         assert.isUndefined(symbolTable.getSymbolId('toString'));
     });
 
-    // See https://github.com/amzn/ion-js/issues/649
+    // See https://github.com/amazon-ion/ion-js/issues/649
     it('Symbol tables do not discard duplicate text during instantiation (Issue #649)', () => {
         const extraSymbols = ["foo", "foo", "bar", "bar"];
         const symbolTable = new LocalSymbolTable(getSystemSymbolTableImport(), extraSymbols);

--- a/test/IonParserBinaryRaw.ts
+++ b/test/IonParserBinaryRaw.ts
@@ -22,7 +22,7 @@ import JSBI from "jsbi";
 /**
  * Tests for reading the UInt primitive follow.
  *
- * Spec: http://amzn.github.io/ion-docs/docs/binary.html#uint-and-int-fields
+ * Spec: https://amazon-ion.github.io/ion-docs/docs/binary.html#uint-and-int-fields
  */
 
 // Returns the largest unsigned integer value that can be stored in `numberOfBits` bits.
@@ -130,7 +130,7 @@ describe('Reading unsigned ints', () => {
 /**
  * Tests for reading the Int primitive follow.
  *
- * Spec: http://amzn.github.io/ion-docs/docs/binary.html#uint-and-int-fields
+ * Spec: https://amazon-ion.github.io/ion-docs/docs/binary.html#uint-and-int-fields
  */
 
 let signedIntBytesMatch = function (bytes: number[], expected: SignAndMagnitudeInt) {
@@ -174,7 +174,7 @@ describe('Reading signed ints', () => {
 /**
  * Tests for reading the VarUInt primitive follow.
  *
- * Spec: http://amzn.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields
+ * Spec: https://amazon-ion.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields
  */
 
 let varUnsignedIntBytesMatchValue = function (bytes: number[], expected: number) {
@@ -227,7 +227,7 @@ describe('Reading variable unsigned ints', () => {
 /**
  * Tests for reading the VarInt primitive follow.
  *
- * Spec: http://amzn.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields
+ * Spec: https://amazon-ion.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields
  */
 
 let varSignedIntBytesMatchValue = function (bytes: number[], expected: number) {
@@ -293,7 +293,7 @@ describe('Reading variable signed ints', () => {
 /**
  * Tests for reading Float values follow.
  *
- * Spec: http://amzn.github.io/ion-docs/docs/binary.html#4-float
+ * Spec: https://amazon-ion.github.io/ion-docs/docs/binary.html#4-float
  */
 
 let serializeFloat = function (value: number, viewType: Float32ArrayConstructor | Float64ArrayConstructor, numberOfBytes: number) {

--- a/test/IonReaderConsistency.ts
+++ b/test/IonReaderConsistency.ts
@@ -11,7 +11,7 @@ describe('IonReaderConsistency', () => {
         {name: 'Pretty', mkInstance: () => ion.makePrettyWriter()},
     ];
 
-    // regression test for https://github.com/amzn/ion-js/issues/514
+    // regression test for https://github.com/amazon-ion/ion-js/issues/514
     writerTypes.forEach(writerType => {
         it('Reads annotations correctly from structs created by a ' + writerType.name + ' writer', () => {
             let writer = writerType.mkInstance();

--- a/test/dom/json.ts
+++ b/test/dom/json.ts
@@ -5,7 +5,7 @@ import {load, Value} from "../../src/dom";
 import {encodeUtf8} from "../../src/IonUnicode";
 
 // Verifies that subtypes of dom.Value down-convert to JSON following the documented process[1].
-// [1] http://amzn.github.io/ion-docs/guides/cookbook.html#down-converting-to-json
+// [1] https://amazon-ion.github.io/ion-docs/guides/cookbook.html#down-converting-to-json
 
 // Calls dom.Value.from() on each Javascript value to create a corresponding Ion value, then verifies that
 // JSON.stringify() produces the same output for both.

--- a/test/dump.ts
+++ b/test/dump.ts
@@ -38,7 +38,7 @@ function roundTripTest(dumpFn: (...values: any[]) => any,
         //      In the meantime, the core writing/equality logic is more strictly tested by
         //      test/dom/Value.ts, which evaluates the data produced by the Value.writeTo() function
         //      at the core of the ion.dump*() methods.
-        //      [1] https://github.com/amzn/ion-js/issues/576
+        //      [1] https://github.com/amazon-ion/ion-js/issues/576
         assert.deepEqual(actualValue.getAnnotations(), expectedValue.getAnnotations());
         assert.equal(actualValue.isNull(), expectedValue.isNull());
         assert.equal(actualValue.getType(), expectedValue.getType());
@@ -82,7 +82,7 @@ describe('dump*()', () => {
         assert.deepEqual(ionValue, ionBinaryValue);
     });
     it('Struct with annotated field large enough to require a VarUInt length', () => {
-        // this ionText is taken from https://github.com/amzn/ion-js/issues/621
+        // this ionText is taken from https://github.com/amazon-ion/ion-js/issues/621
         let ionText = "'com.example.organization.model.data.ClassName2@1.0'::{\n" +
             "  values: [\n" +
             "    'com.example.organization.model.data.ClassName1@1.0'::{\n" +

--- a/test/iontests.ts
+++ b/test/iontests.ts
@@ -352,8 +352,8 @@ let goodSkipList = toSkipList([
   "ion-tests/iontestdata/good/utf16.ion",
   "ion-tests/iontestdata/good/utf32.ion",
   "ion-tests/iontestdata/good/item1.10n",
-  "ion-tests/iontestdata/good/typecodes/T7-large.10n", // https://github.com/amzn/ion-js/issues/541
-  "ion-tests/iontestdata/good/typecodes/T7-small.10n", // https://github.com/amzn/ion-js/issues/541
+  "ion-tests/iontestdata/good/typecodes/T7-large.10n", // https://github.com/amazon-ion/ion-js/issues/541
+  "ion-tests/iontestdata/good/typecodes/T7-small.10n", // https://github.com/amazon-ion/ion-js/issues/541
 ]);
 
 let badSkipList = toSkipList([
@@ -373,44 +373,44 @@ let badSkipList = toSkipList([
   "ion-tests/iontestdata/bad/timestamp/timestampSept31.10n",
   "ion-tests/iontestdata/bad/timestamp/outOfRange/leapDayNonLeapYear_1.10n",
   "ion-tests/iontestdata/bad/timestamp/outOfRange/leapDayNonLeapYear_2.10n",
-  "ion-tests/iontestdata/bad/annotationSymbolIDUnmapped.10n", // https://github.com/amzn/ion-js/issues/542
-  "ion-tests/iontestdata/bad/annotationSymbolIDUnmapped.ion", // https://github.com/amzn/ion-js/issues/542
-  "ion-tests/iontestdata/bad/fieldNameSymbolIDUnmapped.10n", // https://github.com/amzn/ion-js/issues/542
-  "ion-tests/iontestdata/bad/fieldNameSymbolIDUnmapped.ion", // https://github.com/amzn/ion-js/issues/542
-  "ion-tests/iontestdata/bad/timestamp/timestampFraction10d-1.10n", // https://github.com/amzn/ion-js/issues/543
-  "ion-tests/iontestdata/bad/timestamp/timestampFraction11d-1.10n", // https://github.com/amzn/ion-js/issues/543
-  "ion-tests/iontestdata/bad/timestamp/timestampFraction1d0.10n", // https://github.com/amzn/ion-js/issues/543
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_0.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_1.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_10.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_11.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_12.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_13.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_14.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_15.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_2.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_3.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_4.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_5.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_6.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_7.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_8.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_15_length_9.10n", // https://github.com/amzn/ion-js/issues/544
-  "ion-tests/iontestdata/bad/typecodes/type_1_length_10.10n", // https://github.com/amzn/ion-js/issues/545
-  "ion-tests/iontestdata/bad/typecodes/type_1_length_11.10n", // https://github.com/amzn/ion-js/issues/545
-  "ion-tests/iontestdata/bad/typecodes/type_1_length_12.10n", // https://github.com/amzn/ion-js/issues/545
-  "ion-tests/iontestdata/bad/typecodes/type_1_length_13.10n", // https://github.com/amzn/ion-js/issues/545
-  "ion-tests/iontestdata/bad/typecodes/type_1_length_14.10n", // https://github.com/amzn/ion-js/issues/545
-  "ion-tests/iontestdata/bad/typecodes/type_1_length_2.10n", // https://github.com/amzn/ion-js/issues/545
-  "ion-tests/iontestdata/bad/typecodes/type_1_length_3.10n", // https://github.com/amzn/ion-js/issues/545
-  "ion-tests/iontestdata/bad/typecodes/type_1_length_4.10n", // https://github.com/amzn/ion-js/issues/545
-  "ion-tests/iontestdata/bad/typecodes/type_1_length_5.10n", // https://github.com/amzn/ion-js/issues/545
-  "ion-tests/iontestdata/bad/typecodes/type_1_length_6.10n", // https://github.com/amzn/ion-js/issues/545
-  "ion-tests/iontestdata/bad/typecodes/type_1_length_7.10n", // https://github.com/amzn/ion-js/issues/545
-  "ion-tests/iontestdata/bad/typecodes/type_1_length_8.10n", // https://github.com/amzn/ion-js/issues/545
-  "ion-tests/iontestdata/bad/typecodes/type_1_length_9.10n", // https://github.com/amzn/ion-js/issues/545
-  "ion-tests/iontestdata/bad/typecodes/type_3_length_0.10n", // https://github.com/amzn/ion-js/issues/546
-  "ion-tests/iontestdata/bad/typecodes/type_6_length_0.10n", // https://github.com/amzn/ion-js/issues/547
+  "ion-tests/iontestdata/bad/annotationSymbolIDUnmapped.10n", // https://github.com/amazon-ion/ion-js/issues/542
+  "ion-tests/iontestdata/bad/annotationSymbolIDUnmapped.ion", // https://github.com/amazon-ion/ion-js/issues/542
+  "ion-tests/iontestdata/bad/fieldNameSymbolIDUnmapped.10n", // https://github.com/amazon-ion/ion-js/issues/542
+  "ion-tests/iontestdata/bad/fieldNameSymbolIDUnmapped.ion", // https://github.com/amazon-ion/ion-js/issues/542
+  "ion-tests/iontestdata/bad/timestamp/timestampFraction10d-1.10n", // https://github.com/amazon-ion/ion-js/issues/543
+  "ion-tests/iontestdata/bad/timestamp/timestampFraction11d-1.10n", // https://github.com/amazon-ion/ion-js/issues/543
+  "ion-tests/iontestdata/bad/timestamp/timestampFraction1d0.10n", // https://github.com/amazon-ion/ion-js/issues/543
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_0.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_1.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_10.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_11.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_12.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_13.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_14.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_15.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_2.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_3.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_4.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_5.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_6.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_7.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_8.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_9.10n", // https://github.com/amazon-ion/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_10.10n", // https://github.com/amazon-ion/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_11.10n", // https://github.com/amazon-ion/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_12.10n", // https://github.com/amazon-ion/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_13.10n", // https://github.com/amazon-ion/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_14.10n", // https://github.com/amazon-ion/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_2.10n", // https://github.com/amazon-ion/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_3.10n", // https://github.com/amazon-ion/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_4.10n", // https://github.com/amazon-ion/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_5.10n", // https://github.com/amazon-ion/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_6.10n", // https://github.com/amazon-ion/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_7.10n", // https://github.com/amazon-ion/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_8.10n", // https://github.com/amazon-ion/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_9.10n", // https://github.com/amazon-ion/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_3_length_0.10n", // https://github.com/amazon-ion/ion-js/issues/546
+  "ion-tests/iontestdata/bad/typecodes/type_6_length_0.10n", // https://github.com/amazon-ion/ion-js/issues/547
 ]);
 
 let eventSkipList = toSkipList([
@@ -443,12 +443,12 @@ let eventSkipList = toSkipList([
   "ion-tests/iontestdata/good/utf16.ion",
   "ion-tests/iontestdata/good/utf32.ion",
   "ion-tests/iontestdata/good/item1.10n",
-  "ion-tests/iontestdata/good/typecodes/T6-large.10n", // https://github.com/amzn/ion-js/issues/554
-  "ion-tests/iontestdata/good/typecodes/T11.10n", // https://github.com/amzn/ion-js/issues/548
-  "ion-tests/iontestdata/good/typecodes/T12.10n", // https://github.com/amzn/ion-js/issues/548
-  "ion-tests/iontestdata/good/typecodes/T13.10n", // https://github.com/amzn/ion-js/issues/548
-  "ion-tests/iontestdata/good/typecodes/T7-large.10n", // https://github.com/amzn/ion-js/issues/549
-  "ion-tests/iontestdata/good/typecodes/T7-small.10n", // https://github.com/amzn/ion-js/issues/549
+  "ion-tests/iontestdata/good/typecodes/T6-large.10n", // https://github.com/amazon-ion/ion-js/issues/554
+  "ion-tests/iontestdata/good/typecodes/T11.10n", // https://github.com/amazon-ion/ion-js/issues/548
+  "ion-tests/iontestdata/good/typecodes/T12.10n", // https://github.com/amazon-ion/ion-js/issues/548
+  "ion-tests/iontestdata/good/typecodes/T13.10n", // https://github.com/amazon-ion/ion-js/issues/548
+  "ion-tests/iontestdata/good/typecodes/T7-large.10n", // https://github.com/amazon-ion/ion-js/issues/549
+  "ion-tests/iontestdata/good/typecodes/T7-small.10n", // https://github.com/amazon-ion/ion-js/issues/549
 ]);
 
 let readerCompareSkipList = toSkipList([]);
@@ -470,9 +470,9 @@ let equivsSkipList = toSkipList([
   "ion-tests/iontestdata/good/equivs/systemSymbolsAsAnnotations.ion",
   "ion-tests/iontestdata/good/equivs/textNewlines.ion",
 
-  "ion-tests/iontestdata/good/equivs/clobNewlines.ion", // https://github.com/amzn/ion-js/issues/550
-  "ion-tests/iontestdata/good/equivs/localSymbolTableWithAnnotations.ion", // https://github.com/amzn/ion-js/issues/551
-  "ion-tests/iontestdata/good/equivs/longStringsWithComments.ion", // https://github.com/amzn/ion-js/issues/552
+  "ion-tests/iontestdata/good/equivs/clobNewlines.ion", // https://github.com/amazon-ion/ion-js/issues/550
+  "ion-tests/iontestdata/good/equivs/localSymbolTableWithAnnotations.ion", // https://github.com/amazon-ion/ion-js/issues/551
+  "ion-tests/iontestdata/good/equivs/longStringsWithComments.ion", // https://github.com/amazon-ion/ion-js/issues/552
 ]);
 
 let nonEquivsSkipList = toSkipList([

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,7 +1,7 @@
 --require ts-node/register
 --ui mocha-typescript
 --require source-map-support/register
-#Increasing test timeout for node v14, refer To: https://github.com/amzn/ion-js/issues/581
+#Increasing test timeout for node v14, refer To: https://github.com/amazon-ion/ion-js/issues/581
 --timeout 3000
 
 test/*.ts


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:


Updates all links and other references that pointed to Ion repositories in the amzn org to use the amazon-ion org instead.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
