### PR TITLE
Add conditional export for cjs and es6 entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "A JavaScript implementation of the Ion data interchange format",
   "main": "dist/commonjs/es6/Ion.js",
   "types": "dist/commonjs/es6/Ion.d.ts",
+  "exports": {
+    "import": "./dist/es6/es6/Ion.js",
+    "require": "./dist/commonjs/es6/Ion.js"
+  },
   "scripts": {
     "commit": "git-cz",
     "prepare": "grunt release",


### PR DESCRIPTION
### Issue #, if available: #740

### Description of changes:

Added conditional `exports` to `package.json` for the CommonJS and ESModule builds respectively. See node docs on [conditional exports](https://nodejs.org/api/packages.html#conditional-exports).

Tested the commonjs export by using my node REPL and noting that `require.resolve('ion-js')` returns `node_modules/ion-js/dist/commonjs/es6/Ion.js`.

Tested the es6 export by creating a small project containing the code snippet example from the Getting Started section of the README under `src/index.js`, and using `rollup` to build the project. In the tree shaken `node_modules` generated by `rollup`, I can see only `ion-js/dist/es6/es6` is preserved.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
