### PR TITLE
adds changes to allow `dom.Decimal` construction from `Number` and `String`

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "grunt-contrib-clean": "^2.0.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-jshint": "^2.1.0",
-    "grunt-contrib-uglify": "^4.0.1",
+    "grunt-contrib-uglify": "^5.2.2",
     "grunt-eslint": "^23.0.0",
     "grunt-shell": "^3.0.1",
     "grunt-ts": "^6.0.0-beta.22",

--- a/src/dom/Decimal.ts
+++ b/src/dom/Decimal.ts
@@ -60,13 +60,15 @@ export class Decimal extends Value(
       super(value.numberValue());
       this._decimalValue = value;
       this._numberValue = value.numberValue();
-    } else if (typeof value === "number")  {
+    } else if (typeof value === "number") {
       // if value is a number type
       super(value);
       this._decimalValue = new ion.Decimal("" + value);
       this._numberValue = value;
     } else {
-      throw new Error("Decimal value can only be created from number, ion.Decimal or string");
+      throw new Error(
+        "Decimal value can only be created from number, ion.Decimal or string"
+      );
     }
     this._setAnnotations(annotations);
   }

--- a/src/dom/Decimal.ts
+++ b/src/dom/Decimal.ts
@@ -34,7 +34,7 @@ export class Decimal extends Value(
 
   /**
    * Constructor.
-   * @param value         The string value to represent as a decimal.
+   * @param value         The text Ion value to be parsed as a decimal.
    * @param annotations   An optional array of strings to associate with `value`.
    */
   constructor(value: string, annotations?: string[]);
@@ -52,18 +52,21 @@ export class Decimal extends Value(
     annotations: string[] = []
   ) {
     if (typeof value === "string") {
-      super(Number(value));
+      let numberValue = Number(value);
+      super(numberValue);
       this._decimalValue = new ion.Decimal(value);
-      this._numberValue = Number(value);
+      this._numberValue = numberValue;
     } else if (value instanceof ion.Decimal) {
       super(value.numberValue());
       this._decimalValue = value;
       this._numberValue = value.numberValue();
-    } else {
+    } else if (typeof value === "number")  {
       // if value is a number type
       super(value);
       this._decimalValue = new ion.Decimal("" + value);
       this._numberValue = value;
+    } else {
+      throw new Error("Decimal value can only be created from number, ion.Decimal or string");
     }
     this._setAnnotations(annotations);
   }

--- a/src/dom/Decimal.ts
+++ b/src/dom/Decimal.ts
@@ -47,7 +47,10 @@ export class Decimal extends Value(
   constructor(value: number, annotations?: string[]);
 
   // This is the unified implementation of the above signatures and is not visible to users.
-  constructor(value: ion.Decimal | string | number, annotations: string[] = []) {
+  constructor(
+    value: ion.Decimal | string | number,
+    annotations: string[] = []
+  ) {
     if (typeof value === "string") {
       super(Number(value));
       this._decimalValue = new ion.Decimal(value);
@@ -59,7 +62,7 @@ export class Decimal extends Value(
     } else {
       // if value is a number type
       super(value);
-      this._decimalValue = new ion.Decimal(""+value);
+      this._decimalValue = new ion.Decimal("" + value);
       this._numberValue = value;
     }
     this._setAnnotations(annotations);

--- a/src/dom/Decimal.ts
+++ b/src/dom/Decimal.ts
@@ -27,13 +27,41 @@ export class Decimal extends Value(
 
   /**
    * Constructor.
-   * @param value         The numeric value to represent as a decimal.
+   * @param value         The Ion decimal value to represent as a decimal.
    * @param annotations   An optional array of strings to associate with `value`.
    */
-  constructor(value: ion.Decimal, annotations: string[] = []) {
-    super(value.numberValue());
-    this._decimalValue = value;
-    this._numberValue = value.numberValue();
+  constructor(value: ion.Decimal, annotations?: string[]);
+
+  /**
+   * Constructor.
+   * @param value         The string value to represent as a decimal.
+   * @param annotations   An optional array of strings to associate with `value`.
+   */
+  constructor(value: string, annotations?: string[]);
+
+  /**
+   * Constructor.
+   * @param value         The number value to represent as a decimal.
+   * @param annotations   An optional array of strings to associate with `value`.
+   */
+  constructor(value: number, annotations?: string[]);
+
+  // This is the unified implementation of the above signatures and is not visible to users.
+  constructor(value: ion.Decimal | string | number, annotations: string[] = []) {
+    if (typeof value === "string") {
+      super(Number(value));
+      this._decimalValue = new ion.Decimal(value);
+      this._numberValue = Number(value);
+    } else if (value instanceof ion.Decimal) {
+      super(value.numberValue());
+      this._decimalValue = value;
+      this._numberValue = value.numberValue();
+    } else {
+      // if value is a number type
+      super(value);
+      this._decimalValue = new ion.Decimal(""+value);
+      this._numberValue = value;
+    }
     this._setAnnotations(annotations);
   }
 

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 import { load, loadAll, Value } from "../../src/dom";
 import * as ion from "../../src/Ion";
-import { IonTypes } from "../../src/Ion";
+import { dom, IonTypes } from "../../src/Ion";
 import { encodeUtf8 } from "../../src/IonUnicode";
 
 /**
@@ -216,6 +216,9 @@ describe("DOM", () => {
     assert.equal(101.5, +d);
     assert.equal(101.5, d.numberValue());
     assert.isTrue(new ion.Decimal("101.5").equals(d.decimalValue()!));
+    assert.isTrue(new dom.Decimal('101.5').equals(d));
+    assert.isTrue(new dom.Decimal(101.5).equals(d));
+    assert.isFalse(new dom.Decimal(101.0).equals(d));
     assert.equal(1015, Number(d.decimalValue()!.getCoefficient()));
   });
 


### PR DESCRIPTION
### Issue #745:

### Description of changes:
This PR works on allowing dom `Decimal` construction from `Number` or `String`.

## Tests:
adds unit tests to verify construction from `Number` or `String`.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
