### PR TITLE
adds changes for resolving ion-test-driver build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,9 @@
     "semantic-release": "^17.2.3",
     "source-map-support": "^0.5.19",
     "ts-node": "^8.10.1",
-    "typedoc": "^0.23.14",
-    "typescript": "^4.8.3",
+    "typedoc": "^0.20.37",
+    "typescript": "Mixed-in classes with functions returning `this` have TS2526 error is DTS file. Refernce issue: https://github.com/microsoft/TypeScript/issues/52687. Upgrade to a latest typescript version once this issue is resolved",
+    "typescript": "^3.9.10",
     "yargs": "^17.5.1"
   }
 }


### PR DESCRIPTION
### Issue #734, #747:

### Description of changes:
This PR works on changing the `typescript` and `typedoc` versions to resolve generating broken DTS files. Currently typescript has an issue  for mixed-in classes with functions returning `this` have TS2526 error is DTS file.  

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
