### PR TITLE
adds changes for upconverting JS value for dom collections

### DIFF
--- a/src/dom/Sequence.ts
+++ b/src/dom/Sequence.ts
@@ -24,6 +24,16 @@ export function Sequence(ionType: IonType) {
         this.push(child);
       }
       this._setAnnotations(annotations);
+
+      return new Proxy(this, {
+        set: function (target, index, value): boolean {
+          if (!(value instanceof Value)) {
+            value = Value.from(value);
+          }
+          target[index] = value;
+          return true; // Indicates that the assignment succeeded
+        },
+      });
     }
 
     get(...pathElements: PathElement[]): Value | null {

--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -64,6 +64,9 @@ export class Struct extends Value(
       // All values set by the user are stored in `this._fields` to avoid
       // potentially overwriting Struct methods.
       set: function (target, name, value): boolean {
+        if (!(value instanceof Value)) {
+          value = Value.from(value);
+        }
         target._fields[name] = [value];
         return true; // Indicates that the assignment succeeded
       },

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -360,6 +360,11 @@ describe("DOM", () => {
 
     let planets: string[] = l.elements().map((s) => s.stringValue()!);
     assert.equal(4, planets.length);
+
+    // set a JS value into the list that automatically upconverts to dom Value
+    l[0] = "Saturn";
+    assert.equal(l[0], "Saturn");
+    assert.equal(IonTypes.STRING, l[0].getType());
   });
 
   it("load() List as any", () => {
@@ -405,6 +410,11 @@ describe("DOM", () => {
 
     let planets: string[] = s.elements().map((s) => s.stringValue()!);
     assert.equal(4, planets.length);
+
+    // set a JS value into the sexpression that automatically upconverts to dom Value
+    s[0] = "Saturn";
+    assert.equal(s[0], "Saturn");
+    assert.equal(IonTypes.STRING, s[0].getType());
   });
 
   it("load() SExpression as any", () => {
@@ -460,6 +470,11 @@ describe("DOM", () => {
     }
 
     assert.equal(2, s.fields().length);
+
+    // set a field value using a JS value that automatically upconverts to dom Value
+    s["age"] = 43;
+    assert.equal(43, s["age"]);
+    assert.equal(IonTypes.INT, s["age"].getType());
   });
 
   it("load() Struct as any", () => {

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -365,6 +365,7 @@ describe("DOM", () => {
     l[0] = "Saturn";
     assert.equal(l[0], "Saturn");
     assert.equal(IonTypes.STRING, l[0].getType());
+    assert.isTrue(l[0].ionEquals(dom.Value.from("Saturn")));
   });
 
   it("load() List as any", () => {
@@ -415,6 +416,7 @@ describe("DOM", () => {
     s[0] = "Saturn";
     assert.equal(s[0], "Saturn");
     assert.equal(IonTypes.STRING, s[0].getType());
+    assert.isTrue(s[0].ionEquals(dom.Value.from("Saturn")));
   });
 
   it("load() SExpression as any", () => {
@@ -475,6 +477,7 @@ describe("DOM", () => {
     s["age"] = 43;
     assert.equal(43, s["age"]);
     assert.equal(IonTypes.INT, s["age"].getType());
+    assert.isTrue(s["age"].ionEquals(dom.Value.from(43)));
   });
 
   it("load() Struct as any", () => {


### PR DESCRIPTION
### Issue #744

### Description of changes:
This PR works on adds changes for upconverting JS value for dom value collections.

### List of changes:
- adds `Proxy` for `dom.Sequence`
- adds changes for `set()` in `Proxy` in Struct

### Test: 
adds unit tests for upconvertinng JS values to dom values.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
