### PR TITLE
Removes deprecated method `byteValue()` for v5.0.0 release

### DIFF
--- a/src/AbstractWriter.ts
+++ b/src/AbstractWriter.ts
@@ -114,10 +114,10 @@ export abstract class AbstractWriter implements Writer {
         this.writeString(reader.stringValue());
         break;
       case IonTypes.CLOB:
-        this.writeClob(reader.byteValue());
+        this.writeClob(reader.uInt8ArrayValue());
         break;
       case IonTypes.BLOB:
-        this.writeBlob(reader.byteValue());
+        this.writeBlob(reader.uInt8ArrayValue());
         break;
       case IonTypes.LIST:
         this.stepIn(IonTypes.LIST);

--- a/src/IonBinaryReader.ts
+++ b/src/IonBinaryReader.ts
@@ -181,10 +181,6 @@ export class BinaryReader implements Reader {
     return this._raw_type === TB_NULL || this._parser.isNull();
   }
 
-  byteValue(): Uint8Array | null {
-    return this._parser.uInt8ArrayValue();
-  }
-
   uInt8ArrayValue(): Uint8Array | null {
     return this._parser.uInt8ArrayValue();
   }
@@ -254,7 +250,7 @@ export class BinaryReader implements Reader {
         return null;
       case IonTypes.BLOB:
       case IonTypes.CLOB:
-        return this.byteValue();
+        return this.uInt8ArrayValue();
       case IonTypes.BOOL:
         return this.booleanValue();
       case IonTypes.DECIMAL:

--- a/src/IonReader.ts
+++ b/src/IonReader.ts
@@ -132,17 +132,6 @@ export interface Reader {
    * @return `null` if the current Ion value {@link isNull}.
    *
    * @throw Error when the reader is not positioned on a `clob` or `blob` typed value.
-   * @deprecated since version 4.2. Use the `uInt8ArrayValue` method instead.
-   */
-  byteValue(): Uint8Array | null;
-
-  /**
-   * Returns the current value as a `Uint8Array`.  This is only valid if `type() == IonTypes.CLOB`
-   * or `type() == IonTypes.BLOB`.
-   *
-   * @return `null` if the current Ion value {@link isNull}.
-   *
-   * @throw Error when the reader is not positioned on a `clob` or `blob` typed value.
    */
   uInt8ArrayValue(): Uint8Array | null;
 

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -298,10 +298,6 @@ export class TextReader implements Reader {
     throw new Error("Current value is not a Boolean.");
   }
 
-  byteValue(): Uint8Array | null {
-    return this.uInt8ArrayValue();
-  }
-
   uInt8ArrayValue(): Uint8Array | null {
     this.load_raw();
     switch (this._type) {
@@ -423,7 +419,7 @@ export class TextReader implements Reader {
         return null;
       case IonTypes.BLOB:
       case IonTypes.CLOB:
-        return this.byteValue();
+        return this.uInt8ArrayValue();
       case IonTypes.BOOL:
         return this.booleanValue();
       case IonTypes.DECIMAL:

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -110,9 +110,9 @@ function _loadValue(reader: Reader): Value {
     case IonTypes.STRING:
       return new ion.dom.String(reader.stringValue()!, annotations);
     case IonTypes.CLOB:
-      return new Clob(reader.byteValue()!, annotations);
+      return new Clob(reader.uInt8ArrayValue()!, annotations);
     case IonTypes.BLOB:
-      return new Blob(reader.byteValue()!, annotations);
+      return new Blob(reader.uInt8ArrayValue()!, annotations);
     // Containers
     case IonTypes.LIST:
       return _loadList(reader);


### PR DESCRIPTION
### Issue #559

### Description of changes:
This PR works on removing deprecated method `byteValue()` which has  a new replacement `uint8ArrayValue()` method available alternatively.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
