### PR TITLE
Fixes `toJSON()` for `Struct` to correctly return a `dom.Value` instance

### DIFF
--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -182,7 +182,7 @@ export class Struct extends Value(
   }
 
   toJSON() {
-    let normalizedFields = Object.create(null);
+    let normalizedFields = Object.create(Struct.prototype);
     for (const [key, value] of this.fields()) {
       normalizedFields[key] = value;
     }

--- a/test/dom/json.ts
+++ b/test/dom/json.ts
@@ -145,5 +145,17 @@ describe('JSON', () => {
                 JSON.stringify(load('foo'))
             );
         });
+        it('Struct is instanceof dom.Value inside JSON.stringify', () => {
+            let struct: Value = load(`$ion_1_0
+                    {
+                      foo:"bar"
+                    }`)!;
+
+            const replacer = (key, value) => {
+                assert.isTrue(value instanceof Value)
+            }
+
+            JSON.stringify(struct, replacer, 2);
+        })
     });
 });


### PR DESCRIPTION

### Issue #751

### Description of changes:
This PR works on fixing `toJSON()` for `Struct` to correctly return a `dom.Value` instance.

### Solution: 
* `JSON.stringify()` uses `toJSON()` if the object has that defined as per [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior):
> If the value has a toJSON() method, it's responsible to define what data will be serialized. Instead of the object being serialized, the value returned by the toJSON() method when called will be serialized. 
* Previously the `toJSON()` for struct was returning an object based on null object prototype which was giving incorrect results for `instanceof` when called inside the `JSON.stringify` replacer function. 
* Now we are using `Struct`'s prototype to for the return object on `toSJON()`.

### List of changes:
* `Struct#toJSON()` now creates an object based on Struct's prototype instead of null object's prototype.

 ### Tests:
 added a unit test to check for `instanceof dom.Value` inside `JSON.stringify` replacer function.
 
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
