### PR TITLE
modifies `Struct#elements()` to return all field values

### DIFF
--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -149,11 +149,7 @@ export class Struct extends Value(
   }
 
   elements(): Value[] {
-    let singleValueFields = Object.create(null);
-    for (const [fieldName, values] of this.allFields()) {
-      singleValueFields[fieldName] = values[values.length - 1];
-    }
-    return Object.values(singleValueFields);
+    return Object.values(this._fields).flat() as Value[];
   }
 
   [Symbol.iterator](): IterableIterator<[string, Value]> {

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -546,9 +546,9 @@ describe("DOM", () => {
 
     // elements returns values for given Struct where for a fieldname it only contains the last value
     // instead of an array of all values
-    assert.equal(41, s.elements()[0]);
+    assert.equal(55, s.elements()[0]);
     assert.isFalse(Array.isArray(s.elements()[0]));
-    assert.equal("Jessie", s1.elements()[0]["first"]);
+    assert.equal("John", s1.elements()[0]["first"]);
 
     // Iteration
     for (let [fieldName, value] of s) {


### PR DESCRIPTION
### Description of changes:
This PR modifies `Struct#elements()` to return all field values instead of returning the last value for a duplicate field name.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
