### PR TITLE
Updates ion-test-driver workflow to run on ubuntu-latest

### DIFF
--- a/.github/workflows/ion-test-driver.yml
+++ b/.github/workflows/ion-test-driver.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   ion-test-driver:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout ion-js
         uses: actions/checkout@master


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

The `macos-10.15` runner image was [deprecated _last year_](https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/). I see no reason that this has to run specifically on MacOS, so in the interest of frugality, I'm switching to `ubuntu-latest`.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
