### PR TITLE
adds support for local symbol table append read

### DIFF
--- a/src/IonBinaryReader.ts
+++ b/src/IonBinaryReader.ts
@@ -130,7 +130,7 @@ export class BinaryReader implements Reader {
         if (this._parser.getAnnotation(0) !== ion_symbol_table_sid) {
           break;
         }
-        this._symtab = makeSymbolTable(this._cat, this);
+        this._symtab = makeSymbolTable(this._cat, this, this._symtab);
       } else {
         break;
       }

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -190,7 +190,7 @@ export class TextReader implements Reader {
           break;
         }
         this._type = get_ion_type(this._raw_type);
-        this._symtab = makeSymbolTable(this._cat, this);
+        this._symtab = makeSymbolTable(this._cat, this, this._symtab);
         this._raw = undefined;
         this._raw_type = undefined;
       } else {

--- a/test/IonTextReader.ts
+++ b/test/IonTextReader.ts
@@ -97,6 +97,19 @@ class IonTextReaderTests {
         assert.equal(ionReader.stringValue(), 'taco');
     }
 
+    @test "resolves symbol IDs for symbol table append"() {
+        let ionToRead = `$ion_symbol_table::{ symbols:[ "foo", "bar" ]} $ion_symbol_table::{ imports: $ion_symbol_table, symbols:[ "baz" ]}[$10, $11, $12]`;
+        let ionReader = ion.makeReader(ionToRead);
+        ionReader.next();
+        ionReader.stepIn();
+        ionReader.next();
+        assert.equal(ionReader.stringValue(), "foo");
+        ionReader.next();
+        assert.equal(ionReader.stringValue(), "bar");
+        ionReader.next();
+        assert.equal(ionReader.stringValue(), "baz");
+    }
+
     @test "Parse through struct"() {
         let ionToRead = "{ key : \"string\" }";
         let ionReader = ion.makeReader(ionToRead);

--- a/test/iontests.ts
+++ b/test/iontests.ts
@@ -459,7 +459,6 @@ let equivsSkipList = toSkipList([
   "ion-tests/iontestdata/good/equivs/decimalsWithUnderscores.ion",
   "ion-tests/iontestdata/good/equivs/floatsWithUnderscores.ion",
   "ion-tests/iontestdata/good/equivs/intsWithUnderscores.ion",
-  "ion-tests/iontestdata/good/equivs/localSymbolTableAppend.ion",
   "ion-tests/iontestdata/good/equivs/localSymbolTableNullSlots.ion",
   "ion-tests/iontestdata/good/equivs/localSymbolTables.ion",
   "ion-tests/iontestdata/good/equivs/nonIVMNoOps.ion",


### PR DESCRIPTION
### Issue #639

### Description of changes:
This PR adds local symbol table append read support for binary and text reader.

### List of changes: 
- modifies `makeSymbolTable` signature to take current LST value which will be sued to append symbols to current LST.
- If the reader finds `$ion_symbol_table` in the imports then it will perform LST append adding all the symbols to current LST.
- adds unit tests for LST append read support
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
