### PR TITLE
replace `import` specifier with `module`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/commonjs/es6/Ion.js",
   "types": "dist/commonjs/es6/Ion.d.ts",
   "exports": {
-    "import": "./dist/es6/es6/Ion.js",
-    "require": "./dist/commonjs/es6/Ion.js"
+    "module": "./dist/es6/es6/Ion.js",
+    "default": "./dist/commonjs/es6/Ion.js"
   },
   "scripts": {
     "commit": "git-cz",


### PR DESCRIPTION
fixes #764

Prior to this commit ion-js declared a 'import' conditional export, which meant that node would load `./dist/es6/es6/Ion.js` when loaded via import.

However, ion-js's es6 output is not compatible with node because it doesn't use the correct file extension or package.json `type` to indicate it is a esm file, and it's imports do not use file extensions. Node uses the `import` condition whenever a module is loaded with `import`.

Long term it would be good to convert to esm or use `import` but that would require writing and emitting valid ESM, I had some issues with that that I described in the original issue.

As a quick fix I replaced the `import` condition with a `module` condition, which bundlers like esbuild and webpack will prefer.

esbuild uses es6
```
echo "import 'ion-js'" | npx esbuild --bundle --analyze --outfile=/dev/null
  ../../../../../dev/null                      175.2kb  100.0%
   ├ dist/es6/es6/IonParserTextRaw.js           41.5kb   23.7%
```

node can import and require ion-js
```
node -e "require('ion-js')"
node -e "import('ion-js')"
```

https://nodejs.org/docs/latest-v16.x/api/packages.html#subpath-exports https://nodejs.org/docs/latest-v16.x/api/packages.html#conditional-exports https://nodejs.org/docs/latest-v16.x/api/esm.html#mandatory-file-extensions https://esbuild.github.io/api/#how-conditions-work


----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
