### PR TITLE
Fixed h4 formatting in src/dom/README.md

### DIFF
--- a/src/dom/README.md
+++ b/src/dom/README.md
@@ -368,7 +368,7 @@ listSame1.equals(["Mercury", "Venus", "Earth", "Mars"]); // returns true
 listSame1.equals(["Mercury", "Venus", "Earth"]); // returns false because the lists differ with one element "Mars"
 ```
 
-####Struct Example
+#### Struct Example
 ```javascript
 let structSame1: Value = load(
   "foo::bar::{" +


### PR DESCRIPTION
### Issue #, if available: n/a

### Description of changes:

Fixed h4 formatting in src/dom/README.md
Markdown parsers expect headers to have a space between the hash symbols and the text. The missing space prevented `####Struct Example` from being rendered as an h4. Example below:

#### With Space

####Without Space

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
