### PR TITLE
Adds `browserslist` integration for browserify grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,7 +107,7 @@ module.exports = function(grunt) {
          },
         transform: [["babelify", 
                      { 
-                       "presets": ["@babel/preset-env"], // TODO this targets ES2015, we should be more specific
+                       "presets": ["@babel/preset-env"], // Follows the browserslist from package.json
                        "plugins" : [["@babel/transform-runtime"],
                                     ["@babel/transform-object-assign"]]
                      }]],
@@ -123,7 +123,7 @@ module.exports = function(grunt) {
          },
         transform: [["babelify", 
                      { 
-                       "presets": ["@babel/preset-env"], // TODO this targets ES2015, we should be more specific
+                       "presets": ["@babel/preset-env"], // Follows the browserslist from package.json
                        "plugins" : [["@babel/transform-runtime"],
                                     ["@babel/transform-object-assign"]]
                      }]],

--- a/package.json
+++ b/package.json
@@ -92,5 +92,13 @@
     "typescript": "Mixed-in classes with functions returning `this` have TS2526 error is DTS file. Refernce issue: https://github.com/microsoft/TypeScript/issues/52687. Upgrade to a latest typescript version once this issue is resolved",
     "typescript": "^3.9.10",
     "yargs": "^17.5.1"
-  }
+  },
+  "browserslist": [
+    "Chrome >= 80.0",
+    "Firefox >= 80.0",
+    "Opera >= 63.0",
+    "Edge >= 80.0",
+    "Safari >= 14.1",
+    "Samsung >= 12.0"
+  ]
 }


### PR DESCRIPTION
### Issue #773 :

### Description of changes:
This PR fixes the issue of `TypeError: Cannot convert a BigInt value to a number` when importing browser bundle of `ion-js`.

**Issue:** This is a known issue with babel: https://github.com/babel/babel/issues/13109. (this issues also has a suggested solution)

The fix lies in defining `browserslist` in `package.json` for `@babel/preset-env`. From the babel documentation:
> By default @babel/preset-env will use browserslist config sources unless either the `targets` or `ignoreBrowserslistConfig` options are set.

**Fix:** Following the solution specified in https://github.com/babel/babel/issues/13109, added `browserslist` in `package.json`. The list of compatible browsers is gathered from AWS SDK [supported browsers](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-up.html#browsers-supported).

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
